### PR TITLE
Fixed the focus mode's author display so it doesn't always display the author as "- guest -"

### DIFF
--- a/bookwyrm_frontend/src/components/ReviewComponent.vue
+++ b/bookwyrm_frontend/src/components/ReviewComponent.vue
@@ -5,7 +5,7 @@
             <button @click="hideDetail()" class="btn btn-light">show all reviews</button>
             <div class=" p-3">
                 <div class="revDisplay card mt-4 p-2 shadow-sm">
-                    <h2>{{(topic.author == "" || topic.author == null) ? "- Guest -" : topic.author }}</h2>
+                    <h2>{{(topic.user == "" || topic.user == null) ? "- Guest -" : topic.user }}</h2>
                     <div>
                         <RatingComponent
                             v-bind:displayOnly="true"


### PR DESCRIPTION
Pretty quick and easy bug fix
- The reason focus mode always displayed the review author as guest was
 indeed caused by the refactor, that changed the data's key from "author"
  to "user", was incomplete and didn't change the access in focus mode to
   use the new key.
closes #155 